### PR TITLE
Update utils.js

### DIFF
--- a/solutions/beatBoxJS(Solution)/utils.js
+++ b/solutions/beatBoxJS(Solution)/utils.js
@@ -23,7 +23,7 @@ class Button {
     }
 
     createTransitionEndListener = () => {
-        this.element.addEventListener("transitionend", ()=>{
+        this.element.addEventListener("keyup", ()=>{
             this.deselect();
         })
     }


### PR DESCRIPTION
I have changed the transition end event listener to keyup  because if you press a specific key for a long time transition end listener will get confused and it will not remove the background and shadow so we have to change it to keyup for better user experience...hope you accept my pull request